### PR TITLE
Include instruction data in contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "instruction-data"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "crayfish-account-macro",
+ "crayfish-accounts",
+ "crayfish-context",
+ "crayfish-context-macro",
+ "crayfish-handler-macro",
+ "crayfish-program",
+ "crayfish-program-id-macro",
+ "crayfish-space",
+ "crayfish-traits",
+ "litesvm",
+ "pinocchio",
+ "solana-nostd-entrypoint",
+ "solana-program 1.18.26",
+ "solana-sdk",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/accounts/src/accounts/account.rs
+++ b/crates/accounts/src/accounts/account.rs
@@ -30,7 +30,7 @@ where
     }
 }
 
-impl<'a, T> AsRef<RawAccountInfo> for Account<'a, T>
+impl<T> AsRef<RawAccountInfo> for Account<'_, T>
 where
     T: Owner + Pod,
 {
@@ -39,7 +39,7 @@ where
     }
 }
 
-impl<'a, T> ReadableAccount for Account<'a, T>
+impl<T> ReadableAccount for Account<'_, T>
 where
     T: Owner + Pod,
 {

--- a/crates/accounts/src/accounts/mutable.rs
+++ b/crates/accounts/src/accounts/mutable.rs
@@ -71,4 +71,4 @@ where
     }
 }
 
-impl<'a> SignerAccount for Mut<Signer<'a>> {}
+impl SignerAccount for Mut<Signer<'_>> {}

--- a/crates/accounts/src/accounts/program.rs
+++ b/crates/accounts/src/accounts/program.rs
@@ -37,7 +37,7 @@ where
     }
 }
 
-impl<'a, T> AsRef<RawAccountInfo> for Program<'a, T>
+impl<T> AsRef<RawAccountInfo> for Program<'_, T>
 where
     T: ProgramId,
 {
@@ -46,7 +46,7 @@ where
     }
 }
 
-impl<'a, T> ReadableAccount for Program<'a, T>
+impl<T> ReadableAccount for Program<'_, T>
 where
     T: ProgramId,
 {

--- a/crates/accounts/src/accounts/signer.rs
+++ b/crates/accounts/src/accounts/signer.rs
@@ -18,15 +18,15 @@ impl<'a> FromAccountInfo<'a> for Signer<'a> {
     }
 }
 
-impl<'a> AsRef<RawAccountInfo> for Signer<'a> {
+impl AsRef<RawAccountInfo> for Signer<'_> {
     fn as_ref(&self) -> &RawAccountInfo {
         self.info
     }
 }
 
-impl<'a> SignerAccount for Signer<'a> {}
+impl SignerAccount for Signer<'_> {}
 
-impl<'a> ReadableAccount for Signer<'a> {
+impl ReadableAccount for Signer<'_> {
     type DataType = [u8];
 
     fn key(&self) -> &Pubkey {

--- a/crates/accounts/src/accounts/system.rs
+++ b/crates/accounts/src/accounts/system.rs
@@ -20,13 +20,13 @@ impl<'a> FromAccountInfo<'a> for SystemAccount<'a> {
     }
 }
 
-impl<'a> AsRef<RawAccountInfo> for SystemAccount<'a> {
+impl AsRef<RawAccountInfo> for SystemAccount<'_> {
     fn as_ref(&self) -> &RawAccountInfo {
         self.info
     }
 }
 
-impl<'a> ReadableAccount for SystemAccount<'a> {
+impl ReadableAccount for SystemAccount<'_> {
     type DataType = [u8];
 
     fn key(&self) -> &Pubkey {

--- a/crates/accounts/src/accounts/unchecked.rs
+++ b/crates/accounts/src/accounts/unchecked.rs
@@ -13,13 +13,13 @@ impl<'a> FromAccountInfo<'a> for UncheckedAccount<'a> {
     }
 }
 
-impl<'a> AsRef<RawAccountInfo> for UncheckedAccount<'a> {
+impl AsRef<RawAccountInfo> for UncheckedAccount<'_> {
     fn as_ref(&self) -> &RawAccountInfo {
         self.info
     }
 }
 
-impl<'a> ReadableAccount for UncheckedAccount<'a> {
+impl ReadableAccount for UncheckedAccount<'_> {
     type DataType = [u8];
 
     fn key(&self) -> &Pubkey {

--- a/crates/accounts/src/lib.rs
+++ b/crates/accounts/src/lib.rs
@@ -42,7 +42,7 @@ mod sealed {
     pub trait Sealed {}
 
     impl<T> Sealed for Mut<T> where T: ReadableAccount + AsRef<RawAccountInfo> {}
-    impl<'a> Sealed for Signer<'a> {}
+    impl Sealed for Signer<'_> {}
 }
 
 pub trait FromAccountInfo<'a>: Sized {

--- a/crates/context-macro/src/accounts.rs
+++ b/crates/context-macro/src/accounts.rs
@@ -70,7 +70,7 @@ impl<'a> ToTokens for Assign<'a> {
                         Mut::try_from_info(#name)?
                     };
                 }
-            }else {
+            } else {
                 quote! {
                     let #name = <#ty as crayfish_accounts::FromAccountInfo>::try_from_info(#name)?;
                 }

--- a/crates/context-macro/src/accounts.rs
+++ b/crates/context-macro/src/accounts.rs
@@ -39,7 +39,7 @@ impl TryFrom<&mut Field> for Account {
 
 pub struct NameList<'a>(Vec<&'a Ident>);
 
-impl<'a> ToTokens for NameList<'a> {
+impl ToTokens for NameList<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let names = &self.0;
         let expanded = quote! {
@@ -52,7 +52,7 @@ impl<'a> ToTokens for NameList<'a> {
 
 pub struct Assign<'a>(Vec<(&'a Ident, &'a PathSegment, &'a Constraints)>);
 
-impl<'a> ToTokens for Assign<'a> {
+impl ToTokens for Assign<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let assign_fields = self.0.iter().map(|(name, ty, c)| {
             if c.has_init() {

--- a/crates/context-macro/src/arguments.rs
+++ b/crates/context-macro/src/arguments.rs
@@ -1,0 +1,108 @@
+use {
+    proc_macro2::TokenStream,
+    quote::{format_ident, quote, ToTokens},
+    syn::{
+        parse::{Parse, ParseStream},
+        parse2,
+        spanned::Spanned,
+        Attribute, Ident, Path, PathSegment, Token,
+    },
+};
+
+#[derive(Clone, Debug)]
+pub struct Argument {
+    name: Ident,
+    ty: PathSegment,
+}
+
+impl Parse for Argument {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name: Ident = input.parse()?;
+        input.parse::<Token![:]>()?;
+        let ty: Path = input.parse()?;
+        let path_segment = ty
+            .segments
+            .first()
+            .ok_or_else(|| {
+                syn::Error::new(ty.span(), "Expected at least one path segment for type")
+            })?
+            .clone();
+        Ok(Argument {
+            name,
+            ty: path_segment,
+        })
+    }
+}
+
+pub struct Assign<'a>(Vec<(&'a Ident, &'a PathSegment)>);
+
+impl<'a> ToTokens for Assign<'a> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let assign_fields = self.0.iter().map(|(name, ty)| {
+            quote! {
+                let #name = <#ty as crayfish_accounts::FromAccountInfo>::try_from_info(#name)?;
+            }
+        });
+
+        let expanded = quote! {
+            #(#assign_fields)*
+        };
+
+        expanded.to_tokens(tokens);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Arguments(pub Vec<Argument>);
+
+impl Arguments {
+    pub fn generate_struct(&self, name: &Ident) -> (Ident, TokenStream, TokenStream) {
+        let struct_name = format_ident!("{}Args", name);
+
+        let fields = self.0.iter().map(|arg| {
+            let name = &arg.name;
+            let ty = &arg.ty.ident;
+            quote! {
+                pub #name: #ty,
+            }
+        });
+
+        let generated_struct = quote! {
+            #[repr(C)]
+            #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+            pub struct #struct_name {
+                #(#fields)*
+            }
+        };
+
+        let assign = quote! {
+            let args = crayfish_context::args::Args::<#struct_name>::from_entrypoint(accounts, instruction_data)?;
+        };
+
+        (struct_name, generated_struct, assign)
+    }
+}
+
+impl Parse for Arguments {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut arguments = Vec::new();
+        while !input.is_empty() {
+            let arg: Argument = input.parse()?;
+            arguments.push(arg);
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+        Ok(Arguments(arguments))
+    }
+}
+
+impl TryFrom<&mut Attribute> for Arguments {
+    type Error = syn::Error;
+
+    fn try_from(value: &mut Attribute) -> Result<Self, Self::Error> {
+        let tokens = value.meta.require_list()?.tokens.clone();
+        Ok(parse2::<Arguments>(tokens)?)
+    }
+}

--- a/crates/context-macro/src/arguments.rs
+++ b/crates/context-macro/src/arguments.rs
@@ -103,6 +103,6 @@ impl TryFrom<&mut Attribute> for Arguments {
 
     fn try_from(value: &mut Attribute) -> Result<Self, Self::Error> {
         let tokens = value.meta.require_list()?.tokens.clone();
-        Ok(parse2::<Arguments>(tokens)?)
+        parse2::<Arguments>(tokens)
     }
 }

--- a/crates/context-macro/src/arguments.rs
+++ b/crates/context-macro/src/arguments.rs
@@ -36,7 +36,7 @@ impl Parse for Argument {
 
 pub struct Assign<'a>(Vec<(&'a Ident, &'a PathSegment)>);
 
-impl<'a> ToTokens for Assign<'a> {
+impl ToTokens for Assign<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let assign_fields = self.0.iter().map(|(name, ty)| {
             quote! {

--- a/crates/context-macro/src/lib.rs
+++ b/crates/context-macro/src/lib.rs
@@ -1,15 +1,17 @@
 use {
     accounts::{Account, Accounts},
+    arguments::Arguments,
     lifetime::InjectLifetime,
     proc_macro::TokenStream,
     quote::{quote, ToTokens},
     syn::{
         parse::Parse, parse_macro_input, parse_quote, spanned::Spanned, visit_mut::VisitMut,
-        Generics, Ident, Item, Lifetime,
+        Fields, Generics, Ident, Item, Lifetime,
     },
 };
 
 mod accounts;
+mod arguments;
 mod constraints;
 mod lifetime;
 
@@ -18,6 +20,12 @@ pub fn context(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let context = parse_macro_input!(item as Context);
 
     TokenStream::from(context.into_token_stream())
+}
+
+#[proc_macro_attribute]
+pub fn instruction(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    // The macro is declared here but only used as an attribute of the context
+    item
 }
 
 // struct ContextAttributes {
@@ -35,6 +43,7 @@ struct Context {
     generics: Generics,
     item: Item,
     accounts: Accounts,
+    args: Arguments,
 }
 impl Parse for Context {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
@@ -45,6 +54,16 @@ impl Parse for Context {
 
         match item {
             Item::Struct(mut item_struct) => {
+                let args = item_struct
+                    .attrs
+                    .iter_mut()
+                    .filter(|attr| attr.meta.path().is_ident("instruction"))
+                    .map(Arguments::try_from)
+                    .collect::<Result<Vec<Arguments>, syn::Error>>()?
+                    .first()
+                    .unwrap_or(&Arguments(vec![]))
+                    .to_owned();
+
                 let accounts = item_struct
                     .fields
                     .iter_mut()
@@ -56,6 +75,7 @@ impl Parse for Context {
                     generics: item_struct.generics.to_owned(),
                     item: Item::Struct(item_struct),
                     accounts: Accounts(accounts),
+                    args,
                 })
             }
             Item::Enum(_item_enum) => todo!(), // TODO multiple context condition
@@ -69,16 +89,32 @@ impl Parse for Context {
 
 impl ToTokens for Context {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let base_item = &self.item;
+        let account_struct = &mut self.item.to_owned();
         let name = &self.ident;
         let generics = &self.generics;
 
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
         let new_lifetime: Lifetime = parse_quote!('info);
-        let (name_list, assign) = self.accounts.split_for_impl();
+        let (name_list, accounts_assign) = self.accounts.split_for_impl();
+        let (args_struct_name, args_struct, args_assign) = self.args.generate_struct(name);
+
+        // Add an `args` field to the context
+        match account_struct {
+            Item::Struct(account_struct) => match &mut account_struct.fields {
+                Fields::Named(fields) => {
+                    fields.named.push(parse_quote! {
+                        pub args: crayfish_context::args::Args<#new_lifetime, #args_struct_name>
+                    });
+                }
+                _ => (),
+            },
+            _ => panic!("Item is supposed to be a struct"),
+        }
 
         let expanded = quote! {
-            #base_item
+            #args_struct
+
+            #account_struct
 
             impl #impl_generics crayfish_context::HandlerContext<#new_lifetime> for #name #ty_generics #where_clause {
                 fn from_entrypoint(
@@ -89,11 +125,12 @@ impl ToTokens for Context {
                         return Err(ProgramError::NotEnoughAccountKeys);
                     };
 
-                    #assign
+                    #args_assign
+                    #accounts_assign
 
                     *accounts = rem;
 
-                    Ok(#name { #name_list })
+                    Ok(#name { #name_list, args })
                 }
             }
         };

--- a/crates/context-macro/src/lib.rs
+++ b/crates/context-macro/src/lib.rs
@@ -100,14 +100,13 @@ impl ToTokens for Context {
 
         // Add an `args` field to the context
         match account_struct {
-            Item::Struct(account_struct) => match &mut account_struct.fields {
-                Fields::Named(fields) => {
+            Item::Struct(account_struct) => {
+                if let Fields::Named(fields) = &mut account_struct.fields {
                     fields.named.push(parse_quote! {
                         pub args: crayfish_context::args::Args<#new_lifetime, #args_struct_name>
                     });
                 }
-                _ => (),
-            },
+            }
             _ => panic!("Item is supposed to be a struct"),
         }
 

--- a/crates/context-macro/src/lib.rs
+++ b/crates/context-macro/src/lib.rs
@@ -23,7 +23,7 @@ pub fn context(_attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn instruction(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn args(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // The macro is declared here but only used as an attribute of the context
     item
 }
@@ -57,11 +57,11 @@ impl Parse for Context {
                 let args = item_struct
                     .attrs
                     .iter_mut()
-                    .filter(|attr| attr.meta.path().is_ident("instruction"))
+                    .filter(|attr| attr.meta.path().is_ident("args"))
                     .map(Arguments::try_from)
                     .collect::<Result<Vec<Arguments>, syn::Error>>()?
                     .first()
-                    .unwrap_or(&Arguments(vec![]))
+                    .unwrap_or(&Arguments::Values(vec![]))
                     .to_owned();
 
                 let accounts = item_struct
@@ -96,7 +96,7 @@ impl ToTokens for Context {
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
         let new_lifetime: Lifetime = parse_quote!('info);
         let (name_list, accounts_assign) = self.accounts.split_for_impl();
-        let (args_struct_name, args_struct, args_assign) = self.args.generate_struct(name);
+        let (args_struct_name, args_struct, args_assign) = self.args.split_for_impl(name);
 
         // Add an `args` field to the context
         match account_struct {

--- a/crates/context-macro/src/lib.rs
+++ b/crates/context-macro/src/lib.rs
@@ -22,12 +22,6 @@ pub fn context(_attr: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(context.into_token_stream())
 }
 
-#[proc_macro_attribute]
-pub fn args(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    // The macro is declared here but only used as an attribute of the context
-    item
-}
-
 // struct ContextAttributes {
 //     args: Vec<String>,
 // }
@@ -98,14 +92,17 @@ impl ToTokens for Context {
         let (name_list, accounts_assign) = self.accounts.split_for_impl();
         let (args_struct_name, args_struct, args_assign) = self.args.split_for_impl(name);
 
-        // Add an `args` field to the context
         match account_struct {
             Item::Struct(account_struct) => {
+                // Add an `args` field to the context
                 if let Fields::Named(fields) = &mut account_struct.fields {
                     fields.named.push(parse_quote! {
                         pub args: crayfish_context::args::Args<#new_lifetime, #args_struct_name>
                     });
                 }
+
+                // Remove attributes
+                account_struct.attrs.clear();
             }
             _ => panic!("Item is supposed to be a struct"),
         }

--- a/crates/context/src/args.rs
+++ b/crates/context/src/args.rs
@@ -30,7 +30,7 @@ where
         _accounts: &mut &'a [RawAccountInfo],
         instruction_data: &mut &'a [u8],
     ) -> Result<Self, ProgramError> {
-        let arg: &T = try_from_bytes(&instruction_data[0..std::mem::size_of::<T>()])
+        let arg: &T = try_from_bytes(&instruction_data[..std::mem::size_of::<T>()])
             .ok_or(ProgramError::InvalidInstructionData)?;
 
         let (_, remaining) = instruction_data.split_at(std::mem::size_of::<Aligned<A8, T>>());

--- a/crates/context/src/args.rs
+++ b/crates/context/src/args.rs
@@ -30,8 +30,8 @@ where
         _accounts: &mut &'a [RawAccountInfo],
         instruction_data: &mut &'a [u8],
     ) -> Result<Self, ProgramError> {
-        let arg: &T =
-            try_from_bytes(instruction_data).ok_or(ProgramError::InvalidInstructionData)?;
+        let arg: &T = try_from_bytes(&instruction_data[0..std::mem::size_of::<T>()])
+            .ok_or(ProgramError::InvalidInstructionData)?;
 
         let (_, remaining) = instruction_data.split_at(std::mem::size_of::<Aligned<A8, T>>());
         *instruction_data = remaining;

--- a/crates/context/src/args.rs
+++ b/crates/context/src/args.rs
@@ -14,7 +14,7 @@ impl<'a, T> Args<'a, T> {
     }
 }
 
-impl<'a, T> Deref for Args<'a, T> {
+impl<T> Deref for Args<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/traits/src/lamport.rs
+++ b/crates/traits/src/lamport.rs
@@ -34,4 +34,4 @@ pub trait Lamports: WritableAccount + SignerAccount {
     }
 }
 
-impl<'a> Lamports for Mut<Signer<'a>> {}
+impl Lamports for Mut<Signer<'_>> {}

--- a/crates/traits/src/system.rs
+++ b/crates/traits/src/system.rs
@@ -55,5 +55,5 @@ pub trait SystemCpi: WritableAccount {
     }
 }
 
-impl<'a> SystemCpi for Mut<SystemAccount<'a>> {}
-impl<'a> SystemCpi for Mut<SignerAccount<'a>> {}
+impl SystemCpi for Mut<SystemAccount<'_>> {}
+impl SystemCpi for Mut<SignerAccount<'_>> {}

--- a/examples/instruction-data/Cargo.toml
+++ b/examples/instruction-data/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "transfer_sol"
+name = "instruction-data"
 version = "0.1.0"
 edition = "2021"
 publish = false
@@ -14,18 +14,18 @@ pinocchio = ["dep:pinocchio", "crayfish-program/pinocchio"]
 [dependencies]
 bytemuck.workspace = true
 crayfish-accounts.workspace = true
+crayfish-account-macro.workspace = true
 crayfish-context.workspace = true
 crayfish-context-macro.workspace = true
 crayfish-handler-macro.workspace = true
-crayfish-program.workspace = true
-crayfish-traits.workspace = true
+crayfish-program = { workspace = true, features = ["pinocchio"] }
 crayfish-program-id-macro.workspace = true
+crayfish-space.workspace = true
+crayfish-traits.workspace = true
 pinocchio = { workspace = true, optional = true }
 solana-nostd-entrypoint = { workspace = true, optional = true }
 solana-program = { workspace = true, optional = true }
 
 [dev-dependencies]
-aligned.workspace = true
-bytemuck.workspace = true
 litesvm.workspace = true
 solana-sdk.workspace = true

--- a/examples/instruction-data/src/lib.rs
+++ b/examples/instruction-data/src/lib.rs
@@ -5,7 +5,7 @@ use {
         Account, FromAccountInfo, Mut, Program, ReadableAccount, Signer, System, WritableAccount,
     },
     crayfish_context::args::Args,
-    crayfish_context_macro::{context, instruction},
+    crayfish_context_macro::{args, context},
     crayfish_handler_macro::handlers,
     crayfish_program::{msg, program_error::ProgramError},
     crayfish_program_id_macro::program_id,
@@ -13,7 +13,14 @@ use {
 
 program_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+pub struct InitArgs {
+    pub value: u64,
+}
+
 #[context]
+#[args(InitArgs)]
 pub struct InitContext {
     pub payer: Signer,
     #[constraint(
@@ -26,7 +33,7 @@ pub struct InitContext {
 }
 
 #[context]
-#[instruction(value: u64, other_value: u64,)]
+#[args(value: u64, other_value: u64)]
 pub struct SetValueContext {
     pub buffer: Mut<Account<Buffer>>,
 }
@@ -37,7 +44,9 @@ handlers! {
     set_and_add_values,
 }
 
-pub fn initialize(_: InitContext) -> Result<(), ProgramError> {
+pub fn initialize(ctx: InitContext) -> Result<(), ProgramError> {
+    msg!("{}", ctx.args.value);
+
     Ok(())
 }
 

--- a/examples/instruction-data/src/lib.rs
+++ b/examples/instruction-data/src/lib.rs
@@ -5,7 +5,7 @@ use {
         Account, FromAccountInfo, Mut, Program, ReadableAccount, Signer, System, WritableAccount,
     },
     crayfish_context::args::Args,
-    crayfish_context_macro::{args, context},
+    crayfish_context_macro::context,
     crayfish_handler_macro::handlers,
     crayfish_program::{msg, program_error::ProgramError},
     crayfish_program_id_macro::program_id,

--- a/examples/instruction-data/src/lib.rs
+++ b/examples/instruction-data/src/lib.rs
@@ -1,10 +1,13 @@
 use {
     bytemuck::{Pod, Zeroable},
     crayfish_account_macro::account,
-    crayfish_accounts::{Account, FromAccountInfo, Mut, Program, Signer, System, WritableAccount},
+    crayfish_accounts::{
+        Account, FromAccountInfo, Mut, Program, ReadableAccount, Signer, System, WritableAccount,
+    },
+    crayfish_context::args::Args,
     crayfish_context_macro::{context, instruction},
     crayfish_handler_macro::handlers,
-    crayfish_program::program_error::ProgramError,
+    crayfish_program::{msg, program_error::ProgramError},
     crayfish_program_id_macro::program_id,
 };
 
@@ -30,15 +33,32 @@ pub struct SetValueContext {
 
 handlers! {
     initialize,
-    set_value
+    set_value,
+    set_and_add_values,
 }
 
 pub fn initialize(_: InitContext) -> Result<(), ProgramError> {
     Ok(())
 }
 
-pub fn set_value(ctx: SetValueContext) -> Result<(), ProgramError> {
+pub fn set_value(ctx: SetValueContext, more_args: Args<u64>) -> Result<(), ProgramError> {
     ctx.buffer.mut_data()?.value = ctx.args.value;
+    msg!("{}", *more_args);
+
+    Ok(())
+}
+
+pub fn set_and_add_values(
+    ctx_a: SetValueContext,
+    ctx_b: SetValueContext,
+) -> Result<(), ProgramError> {
+    ctx_a.buffer.mut_data()?.value = ctx_a.args.value;
+    ctx_b.buffer.mut_data()?.value = ctx_b.args.value;
+
+    msg!(
+        "{}",
+        ctx_a.buffer.data()?.value + ctx_b.buffer.data()?.value
+    );
 
     Ok(())
 }

--- a/examples/instruction-data/src/lib.rs
+++ b/examples/instruction-data/src/lib.rs
@@ -2,7 +2,7 @@ use {
     bytemuck::{Pod, Zeroable},
     crayfish_account_macro::account,
     crayfish_accounts::{Account, FromAccountInfo, Mut, Program, Signer, System, WritableAccount},
-    crayfish_context_macro::context,
+    crayfish_context_macro::{context, instruction},
     crayfish_handler_macro::handlers,
     crayfish_program::program_error::ProgramError,
     crayfish_program_id_macro::program_id,
@@ -16,37 +16,38 @@ pub struct InitContext {
     #[constraint(
         init,
         payer = payer,
-        space = Counter::SPACE
+        space = Buffer::SPACE
     )]
-    pub counter: Mut<Account<Counter>>,
+    pub buffer: Mut<Account<Buffer>>,
     pub system: Program<System>,
 }
 
 #[context]
-pub struct IncrementContext {
-    pub counter: Mut<Account<Counter>>,
+#[instruction(value: u64, other_value: u64,)]
+pub struct SetValueContext {
+    pub buffer: Mut<Account<Buffer>>,
 }
 
 handlers! {
     initialize,
-    increment
+    set_value
 }
 
 pub fn initialize(_: InitContext) -> Result<(), ProgramError> {
     Ok(())
 }
 
-pub fn increment(ctx: IncrementContext) -> Result<(), ProgramError> {
-    ctx.counter.mut_data()?.count += 1;
+pub fn set_value(ctx: SetValueContext) -> Result<(), ProgramError> {
+    ctx.buffer.mut_data()?.value = ctx.args.value;
 
     Ok(())
 }
 
 #[account]
-pub struct Counter {
-    pub count: u64,
+pub struct Buffer {
+    pub value: u64,
 }
 
-impl Counter {
-    const SPACE: usize = std::mem::size_of::<Counter>();
+impl Buffer {
+    const SPACE: usize = std::mem::size_of::<Buffer>();
 }

--- a/examples/instruction-data/tests/integration.rs
+++ b/examples/instruction-data/tests/integration.rs
@@ -1,0 +1,76 @@
+use {
+    instruction_data::{Buffer, SetValueContextArgs},
+    litesvm::LiteSVM,
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        native_token::LAMPORTS_PER_SOL,
+        pubkey,
+        signature::Keypair,
+        signer::Signer,
+        system_program,
+        transaction::Transaction,
+    },
+    std::path::PathBuf,
+};
+
+fn read_program() -> Vec<u8> {
+    let mut so_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    so_path.push("../../target/deploy/instruction_data.so");
+
+    std::fs::read(so_path).unwrap()
+}
+
+#[test]
+fn integration_test() {
+    let mut svm = LiteSVM::new();
+    let admin_kp = Keypair::new();
+    let admin_pk = admin_kp.pubkey();
+
+    svm.airdrop(&admin_pk, 10 * LAMPORTS_PER_SOL).unwrap();
+
+    let program_id = pubkey::Pubkey::new_from_array(instruction_data::id());
+    let program_bytes = read_program();
+
+    svm.add_program(program_id, &program_bytes);
+
+    let buffer_kp = Keypair::new();
+    let buffer_pk = buffer_kp.pubkey();
+    let ix = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(admin_pk, true),
+            AccountMeta::new(buffer_pk, true),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: vec![0],
+    };
+    let hash = svm.latest_blockhash();
+    let tx =
+        Transaction::new_signed_with_payer(&[ix], Some(&admin_pk), &[&admin_kp, &buffer_kp], hash);
+    svm.send_transaction(tx).unwrap();
+
+    let raw_account = svm.get_account(&buffer_pk).unwrap();
+    let buffer_account: &Buffer = bytemuck::try_from_bytes(raw_account.data.as_slice()).unwrap();
+    assert!(buffer_account.value == 0);
+
+    let ix_args = SetValueContextArgs {
+        value: 10,
+        other_value: 5,
+    };
+    let ix = Instruction {
+        program_id,
+        accounts: vec![AccountMeta::new(buffer_pk, false)],
+        data: vec![1]
+            .iter()
+            .chain(bytemuck::bytes_of(&ix_args).iter())
+            .cloned()
+            .collect(),
+    };
+    let hash = svm.latest_blockhash();
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&admin_pk), &[&admin_kp], hash);
+    svm.send_transaction(tx).unwrap();
+
+    let raw_account = svm.get_account(&buffer_pk).unwrap();
+    let buffer_account: &Buffer = bytemuck::try_from_bytes(raw_account.data.as_slice()).unwrap();
+    assert!(buffer_account.value == ix_args.value);
+}

--- a/examples/instruction-data/tests/integration.rs
+++ b/examples/instruction-data/tests/integration.rs
@@ -60,7 +60,7 @@ fn integration_test() {
     let ix = Instruction {
         program_id,
         accounts: vec![AccountMeta::new(buffer_pk, false)],
-        data: vec![1]
+        data: [1]
             .iter()
             .chain(bytemuck::bytes_of(&ix_args).iter())
             .cloned()

--- a/examples/transfer-sol/src/lib.rs
+++ b/examples/transfer-sol/src/lib.rs
@@ -1,4 +1,5 @@
 use {
+    bytemuck::{Pod, Zeroable},
     crayfish_accounts::{Mut, Program, Signer, System, SystemAccount},
     crayfish_context::args::Args,
     crayfish_context_macro::context,
@@ -28,19 +29,19 @@ pub struct SystemContext {
 
 pub fn transfer_sol_with_cpi(
     amount: Args<u64>,
-    TransferContext { payer, recipient }: TransferContext,
+    ctx: TransferContext,
     _: SystemContext,
 ) -> Result<(), ProgramError> {
-    payer.transfer(&recipient, *amount)?;
+    ctx.payer.transfer(&ctx.recipient, *amount)?;
 
     Ok(())
 }
 
 pub fn transfer_sol_with_program(
     amount: Args<u64>,
-    TransferContext { payer, recipient }: TransferContext,
+    ctx: TransferContext,
 ) -> Result<(), ProgramError> {
-    payer.send(&recipient, *amount)?;
+    ctx.payer.send(&ctx.recipient, *amount)?;
 
     Ok(())
 }


### PR DESCRIPTION
Solves #24 and enables pushing #22 forward.

I chose to create a new `args` field in every context to make these context arguments accessible.